### PR TITLE
handling ref and fallthrough props

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -35,7 +35,7 @@ export default class FloatingLabelInput extends Component {
   }
 
   render() {
-    const { className, fontSize, id, label, onBlur, onChange, onFocus, shrink, placeholder, type, value } = this.props;
+    const { className, fontSize, id, label, onBlur, onChange, onFocus, shrink, placeholder, type, value, refs } = this.props;
     const { active } = this.state;
 
     return (
@@ -82,6 +82,8 @@ export default class FloatingLabelInput extends Component {
             placeholder={placeholder}
             type={type || "text"}
             value={value}
+            ref={refs}
+            {...this.props}
           />
         </div>
       </div>


### PR DESCRIPTION
-- We need to handle fallthrough of this.props for additional input attributes
-- when ref attrbute is used it returns the parent div instead of the input which is the expectation of the user